### PR TITLE
Add --wait option and configurable timeouts

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -20,6 +20,26 @@ period = 895
 # Optional - if not set, broadcasts on all interfaces
 #iface = "eth0"
 
+# Wait for remote server to become available at startup
+# Value is the retry interval in seconds
+# Optional - if not set, dlna-proxy will exit if the server is unavailable at startup
+# Default when enabled: 30
+#wait = 30
+
+# HTTP connect timeout (in seconds) for fetching XML description from remote server
+# Default: 2
+#connect_timeout = 2
+
+# TCP connect timeout (in seconds) for proxy connections to origin server
+# Only applies when proxy is enabled
+# Default: 10
+#proxy_timeout = 10
+
+# TCP read/write timeout (in seconds) for active proxy streams
+# Only applies when proxy is enabled
+# Default: 300 (5 minutes)
+#stream_timeout = 300
+
 # Verbosity level:
 #   0 = Warn (default)
 #   1 = Info

--- a/src/ssdp/broadcast.rs
+++ b/src/ssdp/broadcast.rs
@@ -40,8 +40,8 @@ pub async fn broadcast_task(broadcaster: Arc<SSDPBroadcast>, period: Duration) {
 
     loop {
         if let Err(msg) = broadcaster.do_ssdp_alive().await {
-            warn!(target: "dlnaproxy", "Couldn't send ssdp:alive: {}", msg);
-            break;
+            warn!(target: "dlnaproxy", "Couldn't send ssdp:alive: {}. Will retry next interval.", msg);
+            // Continue instead of break - origin may come back online
         } else {
             info!(target: "dlnaproxy", "Broadcasted on local SSDP channel!");
         }


### PR DESCRIPTION
- Add -w/--wait option to wait for origin server at startup with configurable retry interval (default 30s)
- Add --connect-timeout for HTTP connect timeout (default 2s)
- Add --proxy-timeout for TCP proxy connect timeout (default 10s)
- Add --stream-timeout for TCP read/write timeout (default 300s)
- Fix broadcast loop to continue on failure instead of breaking, allowing recovery when origin server comes back online
- All new options available via CLI and config file